### PR TITLE
Updated the move command to prefix the lib directory with './'

### DIFF
--- a/lib/move_command.dart
+++ b/lib/move_command.dart
@@ -139,7 +139,7 @@ class MoveCommand extends Command<void> {
     // will just pass in the name as the see it in the import statement (e.g. no lib)
     // but when we are validating the actual path we need the lib.
 
-    File actualPath = File(p.canonicalize(p.join("lib", from)));
+    File actualPath = File(p.canonicalize(p.join("./lib", from)));
 
     if (!await actualPath.exists()) {
       fullusage(
@@ -158,7 +158,7 @@ class MoveCommand extends Command<void> {
     // will just pass in the name as the see it in the import statement (e.g. no lib)
     // but when we are validating the actual path we need the lib.
 
-    Directory actualPath = Directory(p.canonicalize(p.join("lib", from)));
+    Directory actualPath = Directory(p.canonicalize(p.join("./lib", from)));
 
     if (!await actualPath.exists()) {
       fullusage(
@@ -176,7 +176,7 @@ class MoveCommand extends Command<void> {
     // the imports don't include lib so devs
     // will just pass in the name as the see it in the import statement (e.g. no lib)
     // but when we are validating the actual path we need the lib.
-    File actualPath = File(p.canonicalize(p.join("lib", to)));
+    File actualPath = File(p.canonicalize(p.join("./lib", to)));
     if (!await actualPath.parent.exists()) {
       fullusage(
           error: "The <toPath> directory does not exist: ${actualPath.parent}");
@@ -191,7 +191,7 @@ class MoveCommand extends Command<void> {
   }
 
   String expandPath(String path) {
-    return p.join("lib", path);
+    return p.join("./lib", path);
   }
 
   bool isDirectory(String path) {


### PR DESCRIPTION
This is a quick fix to #2. Without specifying that the lib directories were local with `./`, `path.join` was not recognizing these as relative directories, and the tool was reporting that the to/from paths did not exist.